### PR TITLE
[Android] Should Initialize MMKV from MainActivity

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,6 +40,7 @@ repositories {
 }
 
 dependencies {
+    //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
     implementation 'com.tencent:mmkv-static:1.2.10'
 }

--- a/android/src/main/java/com/fidme/faststorage/RNFastStorageModule.java
+++ b/android/src/main/java/com/fidme/faststorage/RNFastStorageModule.java
@@ -32,9 +32,7 @@ public class RNFastStorageModule extends ReactContextBaseJavaModule {
       MMKV kv = MMKV.defaultMMKV();
       kv.encode(key, value);
       promise.resolve(value);
-    } catch (Error e) {
-      promise.reject("Error", "Unable to setItem");
-    } catch (Exception e) {
+    } catch (Error | Exception e) {
       promise.reject("Error", "Unable to setItem");
     }
   }
@@ -44,9 +42,7 @@ public class RNFastStorageModule extends ReactContextBaseJavaModule {
     try {
       MMKV kv = MMKV.defaultMMKV();
       promise.resolve(kv.decodeString(key));
-    } catch (Error e) {
-      promise.reject("Error", "Unable to getItem");
-    } catch (Exception e) {
+    } catch (Error | Exception e) {
       promise.reject("Error", "Unable to getItem");
     }
   }
@@ -57,9 +53,7 @@ public class RNFastStorageModule extends ReactContextBaseJavaModule {
       MMKV kv = MMKV.defaultMMKV();
       kv.removeValueForKey(key);
       promise.resolve(key);
-    } catch (Error e) {
-      promise.reject("Error", "Unable to removeItem");
-    } catch (Exception e) {
+    } catch (Error | Exception e) {
       promise.reject("Error", "Unable to removeItem");
     }
   }
@@ -70,9 +64,7 @@ public class RNFastStorageModule extends ReactContextBaseJavaModule {
       MMKV kv = MMKV.defaultMMKV();
       kv.clearAll();
       promise.resolve("Done");
-    } catch (Error e) {
-      promise.reject("Error", "Unable to removeItem");
-    } catch (Exception e) {
+    } catch (Error | Exception e) {
       promise.reject("Error", "Unable to removeItem");
     }
   }

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-import {NativeModules} from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
-const {RNFastStorage} = NativeModules;
+const { RNFastStorage } = NativeModules;
 
-if (RNFastStorage.setupLibrary) RNFastStorage.setupLibrary();
+if (Platform.OS === 'ios' && RNFastStorage.setupLibrary) RNFastStorage.setupLibrary();
 
 export default {
   ...RNFastStorage,


### PR DESCRIPTION

**[ANDROID] Removed setupLibrary (MMKV.initialize method) from React Native logic.**

Now you should init MMKV from your own MainActivity file and don't forget to import `implementation 'com.tencent:mmkv-static:1.2.10'` in your app/build.gradle

By doing so, we are trying to avoid a crash caused by the `MMKV.initialize` method.

    Fatal Exception: java.lang.RuntimeException: Could not invoke RNFastStorage.setupLibrary

       at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:383)
       at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:151)
       at com.facebook.react.bridge.queue.NativeRunnable.run(NativeRunnable.java)
       at android.os.Handler.handleCallback(Handler.java:873)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
       at android.os.Looper.loop(Looper.java:214)
       at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:226)
       at java.lang.Thread.run(Thread.java:764)
